### PR TITLE
Deprecate -openInChrome:withCallbackURL:createNewTab:

### DIFF
--- a/OpenInChromeController.h
+++ b/OpenInChromeController.h
@@ -30,7 +30,7 @@
 #import <Foundation/Foundation.h>
 
 // This class is used to check if Google Chrome is installed in the system and
-// to open a URL in Google Chrome either with or without a callback URL.
+// to open a URL in Google Chrome.
 @interface OpenInChromeController : NSObject
 
 // Returns a shared instance of the OpenInChromeController.
@@ -42,13 +42,13 @@
 // Opens a URL in Google Chrome.
 - (BOOL)openInChrome:(NSURL *)url;
 
-// Open a URL in Google Chrome providing a |callbackURL| to return to the app.
-// URLs from the same app will be opened in the same tab unless |createNewTab|
-// is set to YES.
-// |callbackURL| can be nil.
-// The return value of this method is YES if the URL is successfully opened.
+// iOS displays a "Back to app" link on the device's status line if app was
+// launched from another app. This makes the |callbackURL| parameter much less
+// useful. Chrome has stopped processing the callback URL and create new tab
+// options.
+// @warning DEPRECATED: Please use -openInChrome: directly.
 - (BOOL)openInChrome:(NSURL *)url
      withCallbackURL:(NSURL *)callbackURL
-        createNewTab:(BOOL)createNewTab;
+        createNewTab:(BOOL)createNewTab __attribute__((deprecated));
 
 @end

--- a/OpenInChromeSampleApp/OpenInChromeSampleApp.xcodeproj/project.pbxproj
+++ b/OpenInChromeSampleApp/OpenInChromeSampleApp.xcodeproj/project.pbxproj
@@ -143,11 +143,6 @@
 			attributes = {
 				LastUpgradeCheck = 0450;
 				ORGANIZATIONNAME = "Google Inc.";
-				TargetAttributes = {
-					D1C10435162FF67B0074F0BA = {
-						DevelopmentTeam = EQHXZ8M8AV;
-					};
-				};
 			};
 			buildConfigurationList = D1C10430162FF67B0074F0BA /* Build configuration list for PBXProject "OpenInChromeSampleApp" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -278,7 +273,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
-				DEVELOPMENT_TEAM = EQHXZ8M8AV;
+				DEVELOPMENT_TEAM = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "OpenInChromeSampleApp/OpenInChromeSampleApp-Prefix.pch";
 				INFOPLIST_FILE = "OpenInChromeSampleApp/OpenInChromeSampleApp-Info.plist";
@@ -293,7 +288,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
-				DEVELOPMENT_TEAM = EQHXZ8M8AV;
+				DEVELOPMENT_TEAM = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "OpenInChromeSampleApp/OpenInChromeSampleApp-Prefix.pch";
 				INFOPLIST_FILE = "OpenInChromeSampleApp/OpenInChromeSampleApp-Info.plist";

--- a/OpenInChromeSampleApp/OpenInChromeSampleApp.xcodeproj/project.pbxproj
+++ b/OpenInChromeSampleApp/OpenInChromeSampleApp.xcodeproj/project.pbxproj
@@ -143,6 +143,11 @@
 			attributes = {
 				LastUpgradeCheck = 0450;
 				ORGANIZATIONNAME = "Google Inc.";
+				TargetAttributes = {
+					D1C10435162FF67B0074F0BA = {
+						DevelopmentTeam = EQHXZ8M8AV;
+					};
+				};
 			};
 			buildConfigurationList = D1C10430162FF67B0074F0BA /* Build configuration list for PBXProject "OpenInChromeSampleApp" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -273,10 +278,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
+				DEVELOPMENT_TEAM = EQHXZ8M8AV;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "OpenInChromeSampleApp/OpenInChromeSampleApp-Prefix.pch";
 				INFOPLIST_FILE = "OpenInChromeSampleApp/OpenInChromeSampleApp-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
@@ -287,10 +293,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
+				DEVELOPMENT_TEAM = EQHXZ8M8AV;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "OpenInChromeSampleApp/OpenInChromeSampleApp-Prefix.pch";
 				INFOPLIST_FILE = "OpenInChromeSampleApp/OpenInChromeSampleApp-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;

--- a/OpenInChromeSampleApp/OpenInChromeSampleApp/MainViewController.m
+++ b/OpenInChromeSampleApp/OpenInChromeSampleApp/MainViewController.m
@@ -51,11 +51,8 @@
 - (IBAction)openInChrome:(id)sender {
   NSURL *url = [NSURL URLWithString:_addressField.text];
   [self appendToInfoView:[NSString stringWithFormat:@"Opening %@ in Chrome", url]];
-  NSURL *callbackURL = [NSURL URLWithString:@"myapp://"];
 
-  BOOL success = [[OpenInChromeController sharedInstance] openInChrome:url
-                                                       withCallbackURL:callbackURL
-                                                          createNewTab:NO];
+  BOOL success = [[OpenInChromeController sharedInstance] openInChrome:url];
   [self appendToInfoView:[NSString stringWithFormat:@"Open in Chrome was %@",
       success ? @"successful" : @"unsuccessful"]];
 }

--- a/OpenInChromeSampleApp/OpenInChromeSampleApp/OpenInChromeSampleApp-Info.plist
+++ b/OpenInChromeSampleApp/OpenInChromeSampleApp/OpenInChromeSampleApp-Info.plist
@@ -33,6 +33,11 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>googlechrome</string>
+		<string>googlechromes</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/README.md
+++ b/README.md
@@ -2,20 +2,16 @@
 The easiest way to have your iOS app open links in Chrome is to use the OpenInChromeController class. This API is described here along with the URI schemes it supports.
 
 ## Using OpenInChromeController to open links ##
-The `OpenInChromeController` class provides methods that encapsulate the URI schemes and the scheme replacement process also described in this document. Use this class to check if Chrome is installed, to specify the URL to open, to provide a callback URL, and to force opening in a new tab.
+The `OpenInChromeController` class provides methods that encapsulate the URI schemes and the scheme replacement process also described in this document. Use this class to check if Chrome is installed or to specify the URL to open.
 
 ### Methods ###
   * `isChromeInstalled`: returns YES if Chrome is installed
-  * `openInChrome`: opens a given URL in Chrome; can be used with or without the following
-    * `withCallbackURL`: the URL to which a callback is sent
-    * `createNewTab`: forces the calling app to open the URL in a new tab
+  * `openInChrome`: opens a given URL in Chrome
 
 For example, use the OpenInChromeController class as follows:
 ```
 if ([openInController_ isChromeInstalled]) {
-  [openInController_ openInChrome:urlToOpen
-     withCallbackURL:callbackURL
-     createNewTab:createNewTab];
+  [openInController_ openInChrome:urlToOpen];
 }
 ```
 
@@ -29,7 +25,6 @@ The rest of this document describes the underpinnings of this API.
 Chrome for iOS handles the following URI Schemes:
   * `googlechrome` for http
   * `googlechromes` for https
-  * `googlechrome-x-callback` for callbacks
 
 To check if Chrome is installed, an app can simply check if either of these URI schemes is available:
 ```
@@ -39,7 +34,7 @@ To check if Chrome is installed, an app can simply check if either of these URI 
 
 This step is useful in case an app would like to change the UI depending on if Chrome is installed or not. For instance the app could add an option to open URLs in Chrome in a share menu or action sheet.
 
-To actually open a URL in Chrome, the URI scheme provided in the URL must be changed from `http` or `https` to the Google Chrome equivalent. 
+To actually open a URL in Chrome, the URI scheme provided in the URL must be changed from `http` or `https` to the Google Chrome equivalent of `googlechrome` or `googlechromes` respectively.
 
 The following sample code opens a URL in Chrome:
 ```
@@ -75,85 +70,5 @@ If Chrome is not installed the user can be prompted to download it from the App 
 ```
 [[UIApplication sharedApplication] openURL:[NSURL URLWithString:
     @"itms-apps://itunes.apple.com/us/app/chrome/id535886823"]];
-```
-
-## Using the x-callback-url registration scheme to return ##
-Chrome for iOS also supports [x-callback-url](http://x-callback-url.com/specifications/), an open specification for inter-app communications and messaging between iOS apps that provides a way for the application opened in Chrome to specify a callback URL to return to the calling app. Applications supporting `x-callback-url` have to register a URL scheme that will be used to call the app with compliant URLs.
-
-The URI scheme that Chrome registers for x-callback-url is:
-  * `googlechrome-x-callback`
-
-This scheme will accept `x-callback-url` compliant URLs with the *open* action and the following parameters:
-  * `url`: (required) the URL to open
-  * `x-success`: (optional) the URL to call for the return when the operation completes successfully
-  * `x-source`: (optional; required if x-success is specified): the application name to where the calling app returns
-  * `create-new-tab`: (optional) forces the creation of a new tab in the calling app
-
-For example:
-```
-googlechrome-x-callback://x-callback-url/open/?url=http%3A%2F%2Fwww.google.com
-```
-
-## Checking if x-callback-url is available in Chrome ##
-
-The `x-callback-url` parameters are supported in Google Chrome as of version 23.0. Previous versions of Chrome are not registered for the `googlechrome-x-callback` URL scheme. It’s important for apps to check if the URL scheme is registered before trying to invoke the `googlechrome-x-callback` scheme.
-
-To check if Chrome with `x-callback-url` is installed, an app can use the following code:
-```
-[[UIApplication sharedApplication] canOpenURL:
-    [NSURL URLWithString:@"googlechrome-x-callback://"]];
-```
-
-Once it has been determined that Google Chrome with `x-callback-url` is installed, the app can then open a URL in Chrome specifying a callback URL as in the following example.
-```
-// Method to escape parameters in the URL.
-static NSString * encodeByAddingPercentEscapes(NSString *input) {
-  NSString *encodedValue =
-      (NSString *)CFURLCreateStringByAddingPercentEscapes(
-          kCFAllocatorDefault,
-          (CFStringRef)input,
-          NULL,
-          (CFStringRef)@"!*'();:@&=+$,/?%#[]",
-          kCFStringEncodingUTF8);
-  return [encodedValue autorelease];
-}
-…
-NSString *appName =
-    [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
-NSURL *inputURL = <the URL to open>;
-NSURL *callbackURL = <the callback URL>;
-
-NSString *scheme = inputURL.scheme;
-
-// Proceed only if scheme is http or https.
-if ([scheme isEqualToString:@"http"] ||
-    [scheme isEqualToString:@"https"]) {
-  NSString *chromeURLString = [NSString stringWithFormat:
-      @"googlechrome-x-callback://x-callback-url/open/?x-source=%@&x-success=%@&url=%@",
-      encodeByAddingPercentEscapes(appName),
-      encodeByAddingPercentEscapes([callbackURL absoluteString]),
-      encodeByAddingPercentEscapes([inputURL absoluteString])];
-  NSURL *chromeURL = [NSURL URLWithString:chromeURLString];
-
-  // Open the URL with Google Chrome.
-  [[UIApplication sharedApplication] openURL:chromeURL];
-}
-```
-
-## Enabling a callback with x-success ##
-The calling application can also specify a URL as callback when the user finishes the navigation using the `x-success` parameter in the `x-callback-url`. When specifying `x-success` with the callback URL you must also specify the application name (via the `x-source` parameter), which will be displayed in Chrome as a hint to the user for how to return to the calling application. Failing to provide the app name will result in the `x-success` parameter to be discarded and ignored.
-
-For example:
-```
-googlechrome-x-callback://x-callback-url/open/?x-source=MyApp&x-success=com.myapp.callback%3A%2F%2F&url=http%3A%2F%2Fwww.google.com
-```
-
-In this case the callback URL specified is `com.myapp.callback://` and Chrome will call back to the calling app on that URL when the user has finished the navigation. The application name, specified using the x-source parameter, is *MyApp*, and it will be shown as a replacement of the back button when the user can return to the calling application.
-
-### Creating a new tab ###
-By default, Chrome reuses the same tab when opened by the same application. To override this default behavior, the calling app should provide the `create-new-tab` parameter as part of the action parameter in the x-callback-url URL.
-For example:
-```
-googlechrome-x-callback://x-callback-url/open/?x-source=MyApp&x-success=com.myapp.callback%3A%2F%2F&url=http%3A%2F%2Fwww.google.com&create-new-tab
 ```
 


### PR DESCRIPTION
With iOS' native support of "Back to App" link on the status bar, Chrome stopped supporting Callback URL and create-new-tab options on the x-callback-url.

This change preserves the previous APIs, but moved the implementation into -openInChrome: and made -openInChrome:withCallbackURL:createNewTab: a wrapper function for backward compatibility.

Also updated the sample app with Info.plist so -canOpenURL: call works.